### PR TITLE
fix a conflict when using SaveAs on a previously saved series

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -6,7 +6,7 @@
 		         changingPattern=".*SNAPSHOT"/>
 		<!--<ibiblio name="my-maven" m2compatible="true" root="http://repo.maven.apache.org/maven2/"/>-->
 		<!--<ibiblio name="staging" m2compatible="true" root="https://oss.sonatype.org/content/repositories/orgagileclick-1008"/>-->
-		<ibiblio name="central" m2compatible="true"/>
+		<ibiblio name="central" m2compatible="true" root="https://repo1.maven.org/maven2/" />
 
 		<filesystem name="local-m2-publish" m2compatible="true">
 			<artifact

--- a/src/main/java/org/kairosdb/core/aggregator/SaveAsAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/SaveAsAggregator.java
@@ -133,7 +133,13 @@ public class SaveAsAggregator implements Aggregator, GroupByAware
 		{
 			m_innerDataPointGroup = innerDataPointGroup;
 			ImmutableSortedMap.Builder<String, String> mapBuilder = ImmutableSortedMap.naturalOrder();
-			mapBuilder.putAll(m_tags);
+
+			for (Map.Entry<String, String> tag : m_tags.entrySet()) {
+				if (tag.getKey() != "saved_from" || !m_addSavedFrom) {
+					mapBuilder.put(tag);
+				}
+			}
+
 			if (m_addSavedFrom)
 				mapBuilder.put("saved_from", innerDataPointGroup.getName());
 


### PR DESCRIPTION
If you `save_as` a metric that's been previous stored via `save_as`, the `saved_from` tag will conflict on each series.