### PR TITLE
add an endpoint to get the cardinality relevant to a query

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/Datastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/Datastore.java
@@ -25,4 +25,6 @@ public interface Datastore
 	void deleteDataPoints(DatastoreMetricQuery deleteQuery) throws DatastoreException;
 
 	TagSet queryMetricTags(DatastoreMetricQuery query) throws DatastoreException;
+
+	long queryCardinality(DatastoreMetricQuery query) throws DatastoreException;
 }

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -255,10 +255,7 @@ public class KairosDatastore implements KairosPostConstructInit
 
 	public long queryCardinality(QueryMetric metric) throws DatastoreException
 	{
-		if (!(m_datastore instanceof H2Datastore)) {
-			throw new RuntimeException("need H2 datastore for cardinality query, but have " + m_datastore.getClass());
-		}
-		return ((H2Datastore) m_datastore).queryCardinality(metric);
+		return m_datastore.queryCardinality(metric);
 	}
 
 	public DatastoreQuery createQuery(QueryMetric metric) throws DatastoreException

--- a/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
+++ b/src/main/java/org/kairosdb/core/datastore/KairosDatastore.java
@@ -31,6 +31,7 @@ import org.kairosdb.core.groupby.TagGroupBy;
 import org.kairosdb.core.groupby.TagGroupByResult;
 import org.kairosdb.core.groupby.TypeGroupByResult;
 import org.kairosdb.core.reporting.ThreadReporter;
+import org.kairosdb.datastore.h2.H2Datastore;
 import org.kairosdb.plugin.Aggregator;
 import org.kairosdb.plugin.GroupBy;
 import org.kairosdb.util.MemoryMonitor;
@@ -249,6 +250,15 @@ public class KairosDatastore implements KairosPostConstructInit
 
 		return Collections.<DataPointGroup>singletonList(new EmptyDataPointGroup(metric.getName(), tagSet));
 
+	}
+
+
+	public long queryCardinality(QueryMetric metric) throws DatastoreException
+	{
+		if (!(m_datastore instanceof H2Datastore)) {
+			throw new RuntimeException("need H2 datastore for cardinality query, but have " + m_datastore.getClass());
+		}
+		return ((H2Datastore) m_datastore).queryCardinality(metric);
 	}
 
 	public DatastoreQuery createQuery(QueryMetric metric) throws DatastoreException

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -396,6 +396,20 @@ public class CassandraDatastore implements Datastore, ProcessorHandler, KairosMe
 	}
 
 	@Override
+	public long queryCardinality(final DatastoreMetricQuery query) throws DatastoreException {
+		Iterator<DataPointsRowKey> rowKeys = getKeysForQueryIterator(query);
+
+		long result = 0;
+		while (rowKeys.hasNext())
+		{
+			rowKeys.next();
+			result += 1;
+		}
+
+		return result;
+	}
+
+	@Override
 	public void setValue(String service, String serviceKey, String key, String value) throws DatastoreException
 	{
 		BoundStatement statement = new BoundStatement(m_metaCluster.psServiceIndexInsert);

--- a/src/main/java/org/kairosdb/datastore/h2/H2Datastore.java
+++ b/src/main/java/org/kairosdb/datastore/h2/H2Datastore.java
@@ -518,6 +518,7 @@ public class H2Datastore implements Datastore, ServiceKeyStore
 		return tagSet;
 	}
 
+	@Override
 	public long queryCardinality(DatastoreMetricQuery query) throws DatastoreException
 	{
 		GenOrmQueryResultSet<? extends MetricIdResults> idQuery = getMetricIdsForQuery(query);

--- a/src/main/java/org/kairosdb/datastore/h2/H2Datastore.java
+++ b/src/main/java/org/kairosdb/datastore/h2/H2Datastore.java
@@ -518,6 +518,24 @@ public class H2Datastore implements Datastore, ServiceKeyStore
 		return tagSet;
 	}
 
+	public long queryCardinality(DatastoreMetricQuery query) throws DatastoreException
+	{
+		GenOrmQueryResultSet<? extends MetricIdResults> idQuery = getMetricIdsForQuery(query);
+		long result = 0;
+		try
+		{
+			while (idQuery.next()) {
+				result += 1;
+			}
+		}
+		finally
+		{
+			idQuery.close();
+		}
+
+		return result;
+	}
+
 	@Override
 	public void setValue(String service, String serviceKey, String key, String value) throws DatastoreException
 	{

--- a/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
@@ -471,4 +471,10 @@ public class RemoteDatastore implements Datastore
 	{
 		throw new DatastoreException("Method not implemented.");
 	}
+
+	@Override
+	public long queryCardinality(DatastoreMetricQuery query) throws DatastoreException
+	{
+		throw new DatastoreException("Method not implemented.");
+	}
 }

--- a/src/test/java/org/kairosdb/core/datastore/KairosDatastoreTest.java
+++ b/src/test/java/org/kairosdb/core/datastore/KairosDatastoreTest.java
@@ -395,6 +395,12 @@ public class KairosDatastoreTest
 		}
 
 		@Override
+		public long queryCardinality(DatastoreMetricQuery query)
+		{
+			return 0;
+		}
+
+		@Override
 		public void setValue(String service, String serviceKey, String key, String value)
 		{
 

--- a/src/test/java/org/kairosdb/core/http/rest/ResourceBase.java
+++ b/src/test/java/org/kairosdb/core/http/rest/ResourceBase.java
@@ -225,6 +225,12 @@ public abstract class ResourceBase
         }
 
         @Override
+        public long queryCardinality(DatastoreMetricQuery query)
+        {
+            return 0;
+        }
+
+        @Override
         public void setValue(String service, String serviceKey, String key, String value) throws DatastoreException
         {
             if (m_toThrow != null)

--- a/src/test/java/org/kairosdb/core/http/rest/json/DataPointsParserTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/json/DataPointsParserTest.java
@@ -774,6 +774,12 @@ public class DataPointsParserTest
 		}
 
 		@Override
+		public long queryCardinality(DatastoreMetricQuery query)
+		{
+			return 0;
+		}
+
+		@Override
 		public void setValue(String service, String serviceKey, String key, String value) throws DatastoreException
 		{
 

--- a/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
+++ b/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
@@ -399,5 +399,11 @@ public class PutCommandTest
 		{
 			return null;
 		}
+
+		@Override
+		public long queryCardinality(DatastoreMetricQuery query)
+		{
+			return 0;
+		}
 	}
 }

--- a/src/test/java/org/kairosdb/rollup/RollUpJobTest.java
+++ b/src/test/java/org/kairosdb/rollup/RollUpJobTest.java
@@ -361,5 +361,11 @@ public class RollUpJobTest
 		{
 			throw new UnsupportedOperationException();
 		}
+
+		@Override
+		public long queryCardinality(DatastoreMetricQuery query)
+		{
+			throw new UnsupportedOperationException();
+		}
 	}
 }


### PR DESCRIPTION
Adds the `/api/v1/datapoints/query/cardinality` endpoint, which returns how many distinct combinations of tags are relevant to the given query. For some datastores (Cassandra and H2, at least), query time is roughly proportional to this cardinality, so this endpoint is useful for estimating how expensive a query will be.

Functional test, running it locally (with `java make run`, which I believe uses the H2 datastore by default):
```
~ $ curl --silent --fail 'http://localhost:8080/api/v1/datapoints/query/tags' -H 'content-type: application/json' -H 'origin: https://grafana.pp.dropbox.com' --data-binary '{"cache_time":0,"start_absolute":0,"metrics":[{"name":"kairosdb.protocol.http_request_count"}]}' --compressed | jq
{
  "queries": [
    {
      "results": [
        {
          "name": "kairosdb.protocol.http_request_count",
          "tags": {
            "host": [
              "spencerpearson-mbp.corp.dropbox.com"
            ],
            "method": [
              "cardinality",
              "metricnames",
              "tags"
            ]
          },
          "values": []
        }
      ]
    }
  ]
}
~ $ curl --silent --fail 'http://localhost:8080/api/v1/datapoints/query/cardinality' -H 'content-type: application/json' --data-binary '{"cache_time":0,"start_absolute":0,"metrics":[{"name":"kairosdb.protocol.http_request_count"}]}' --compressed | jq
{
  "queryCardinalities": [
    3
  ]
}
~ $ curl --silent --fail 'http://localhost:8080/api/v1/datapoints/query/cardinality' -H 'content-type: application/json' --data-binary '{"cache_time":0,"start_absolute":0,"metrics":[{"name":"kairosdb.protocol.http_request_count", "tags":{"method":["cardinality"]}}]}' --compressed | jq
{
  "queryCardinalities": [
    1
  ]
}
~ $ curl --silent --fail 'http://localhost:8080/api/v1/datapoints/query/cardinality' -H 'content-type: application/json' --data-binary '{"cache_time":0,"start_absolute":0,"metrics":[{"name":"kairosdb.protocol.http_request_count", "tags":{"method":["cardinality","tags"]}}]}' --compressed | jq
{
  "queryCardinalities": [
    2
  ]
}
```