### PR TITLE
Execute Cassandra queries synchronously instead of spinning them off into futures whose results never get checked (which silently drops any exception that happens).

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
@@ -156,14 +156,14 @@ public class CQLBatch
 	{
 		if (metricNamesBatch.size() != 0)
 		{
-			m_clusterConnection.executeAsync(metricNamesBatch);
+			m_clusterConnection.execute(metricNamesBatch);
 			m_batchStats.addNameBatch(metricNamesBatch.size());
 		}
 
 		if (rowKeyBatch.size() != 0)
 		{
 			//rowKeyBatch.enableTracing();
-			m_clusterConnection.executeAsync(rowKeyBatch);
+			m_clusterConnection.execute(rowKeyBatch);
 			m_batchStats.addRowKeyBatch(rowKeyBatch.size());
 		}
 


### PR DESCRIPTION
Sure, this will slow things down, but probably ... not fatally so? Slow and debuggable >> fast and incomprehensible, surely.